### PR TITLE
Network brokerage v2

### DIFF
--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -1010,7 +1010,7 @@ class AtlasProdJobBroker (JobBrokerBase):
                 except KeyError:
                     continue
 
-                if site == nucleus: # Don't compare against site transferrring to itself
+                if site == nucleus:  # Don't compare against site transferring to itself
                     continue
 
                 for metric in [FTS_1H, FTS_1D, FTS_1W]:
@@ -1081,8 +1081,9 @@ class AtlasProdJobBroker (JobBrokerBase):
                     mbps = networkMap[tmpAtlasSiteName][FTS_1D]
                     mbps = networkMap[tmpAtlasSiteName][FTS_1H]
                 except KeyError:
-                    tmpLog.debug('No dynamic FTS mbps information found in network matrix from {0}({1}) to {2}'.
-                                 format(tmpAtlasSiteName, tmpSiteName, nucleus))
+                    if mbps is None:
+                        tmpLog.debug('No dynamic FTS mbps information found in network matrix from {0}({1}) to {2}'.
+                                     format(tmpAtlasSiteName, tmpSiteName, nucleus))
 
                 # network weight: value between 1 and 2, except when nucleus == satellite
                 if nucleus == tmpAtlasSiteName: # 25 per cent weight boost for processing in nucleus itself

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -1167,7 +1167,7 @@ class AtlasProdJobBroker (JobBrokerBase):
                 ngMsg += '{0} '.format(weightStr)
                 ngMsg += 'criteria=-cap'
             elif taskSpec.useWorldCloud() and self.nwActive and inputChunk.isExpress() \
-                    and weightNw < self.nw_threshold * self.nw:
+                    and weightNw < self.nw_threshold * self.nw_weight_multiplier:
                 ngMsg = '  skip site={0} due to low network weight for express task weightNw={1} threshold={2}'\
                     .format(tmpSiteName, weightNw, self.nw_threshold)
                 ngMsg += '{0} '.format(weightStr)

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -1001,17 +1001,21 @@ class AtlasProdJobBroker (JobBrokerBase):
         newScanSiteList = []
 
         # Get the maximum throughput between the satellite candidates to the nucleus
-        max_mbps_to_nucleus = 0
-        for queue in scanSiteList:
+        if taskSpec.useWorldCloud() and nucleus:
+            max_mbps_to_nucleus = 0
+            for queue in scanSiteList:
 
-            try:
-                site = siteMapping[queue]
-            except KeyError:
-                continue
+                try:
+                    site = siteMapping[queue]
+                except KeyError:
+                    continue
 
-            for metric in [FTS_1H, FTS_1D, FTS_1W]:
-                if networkMap[site].has_key(metric) and networkMap[site][metric] > max_mbps_to_nucleus:
-                    max_mbps_to_nucleus = networkMap[site][metric]
+                if site == nucleus: # Don't compare against site transferrring to itself
+                    continue
+
+                for metric in [FTS_1H, FTS_1D, FTS_1W]:
+                    if networkMap[site].has_key(metric) and networkMap[site][metric] > max_mbps_to_nucleus:
+                        max_mbps_to_nucleus = networkMap[site][metric]
 
         for tmpSiteName in scanSiteList:
             tmpSiteSpec = self.siteMapper.getSite(tmpSiteName)

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -83,7 +83,7 @@ class AtlasProdJobBroker (JobBrokerBase):
 
     # sends a json message to ES. QUICK HACK FOR EXPERIMENTATION. SHOULD BE INCLUDED IN PANDA-COMMON
     def sendNetworkMessage(self, taskID, src, dst, weight, weightNw, weightNwThroughput,
-                           weightNwQueued, mbps, max_mbps, closeness, nqueued, tmpLog):
+                           weightNwQueued, mbps, closeness, nqueued, tmpLog):
         name = 'panda.mon.jedi'
         module = 'network_brokerage'
 
@@ -106,7 +106,6 @@ class AtlasProdJobBroker (JobBrokerBase):
                     'weightNwThroughput': weightNwThroughput,
                     'weightNwQueued': weightNwQueued,
                     'mbps': mbps,
-                    'max_mbps': max_mbps,
                     'closeness': closeness,
                     'nqueued': nqueued,
                     'msg': 'network data'}
@@ -1106,7 +1105,7 @@ class AtlasProdJobBroker (JobBrokerBase):
                     weight *= weightNw
 
                 self.sendNetworkMessage(taskSpec.jediTaskID, tmpAtlasSiteName, nucleus, weight, weightNw,
-                                        weightNwThroughput, weightNwQueue, mbps, max_mbps_to_nucleus, closeness,
+                                        weightNwThroughput, weightNwQueue, mbps, closeness,
                                         nFilesInQueue, tmpLog)
 
             # make candidate

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -83,7 +83,7 @@ class AtlasProdJobBroker (JobBrokerBase):
 
     # sends a json message to ES. QUICK HACK FOR EXPERIMENTATION. SHOULD BE INCLUDED IN PANDA-COMMON
     def sendNetworkMessage(self, taskID, src, dst, weight, weightNw, weightNwThroughput,
-                           weightNwQueue, mbps, max_mbps, closeness, queued, tmpLog):
+                           weightNwQueued, mbps, max_mbps, closeness, nqueued, tmpLog):
         name = 'panda.mon.jedi'
         module = 'network_brokerage'
 
@@ -104,12 +104,11 @@ class AtlasProdJobBroker (JobBrokerBase):
                     'weight': weight,
                     'weightNw': weightNw,
                     'weightNwThroughput': weightNwThroughput,
-                    'weightNwQueue': weightNwQueue,
+                    'weightNwQueued': weightNwQueued,
                     'mbps': mbps,
                     'max_mbps': max_mbps,
                     'closeness': closeness,
-                    'ntransferred': transferred,
-                    'nqueued': queued,
+                    'nqueued': nqueued,
                     'msg': 'network data'}
 
             arr=[{

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -82,8 +82,8 @@ class AtlasProdJobBroker (JobBrokerBase):
         tmpLog.debug('sent')
 
     # sends a json message to ES. QUICK HACK FOR EXPERIMENTATION. SHOULD BE INCLUDED IN PANDA-COMMON
-    def sendNetworkMessage(self, taskID, src, dst, weight, weightNw, weightDynamic,
-                           weightStatic, closeness, transferred, queued, tmpLog):
+    def sendNetworkMessage(self, taskID, src, dst, weight, weightNw, weightNwThroughput,
+                           weightNwQueue, mbps, max_mbps, closeness, queued, tmpLog):
         name = 'panda.mon.jedi'
         module = 'network_brokerage'
 
@@ -103,8 +103,10 @@ class AtlasProdJobBroker (JobBrokerBase):
                     'dst': dst,
                     'weight': weight,
                     'weightNw': weightNw,
-                    'weightDynamic': weightDynamic,
-                    'weightStatic': weightStatic,
+                    'weightNwThroughput': weightNwThroughput,
+                    'weightNwQueue': weightNwQueue,
+                    'mbps': mbps,
+                    'max_mbps': max_mbps,
                     'closeness': closeness,
                     'ntransferred': transferred,
                     'nqueued': queued,
@@ -1104,7 +1106,7 @@ class AtlasProdJobBroker (JobBrokerBase):
                     weight *= weightNw
 
                 self.sendNetworkMessage(taskSpec.jediTaskID, tmpAtlasSiteName, nucleus, weight, weightNw,
-                                        weightNwDynamic, weightNwStatic, closeness, nFilesTransferred,
+                                        weightNwThroughput, weightNwQueue, mbps, max_mbps_to_nucleus, closeness,
                                         nFilesInQueue, tmpLog)
 
             # make candidate

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -1167,7 +1167,7 @@ class AtlasProdJobBroker (JobBrokerBase):
                 ngMsg += 'criteria=-cap'
             elif taskSpec.useWorldCloud() and self.nwActive and inputChunk.isExpress() \
                     and weightNw < self.nw_threshold * self.nw_weight_multiplier:
-                ngMsg = '  skip site={0} due to low network weight for express task weightNw={1} threshold={2}'\
+                ngMsg = '  skip site={0} due to low network weight for express task weightNw={1} threshold={2} '\
                     .format(tmpSiteName, weightNw, self.nw_threshold)
                 ngMsg += '{0} '.format(weightStr)
                 ngMsg += 'criteria=-lowNetworkWeight'

--- a/pandajedi/jeditest/jobSplitterTest.py
+++ b/pandajedi/jeditest/jobSplitterTest.py
@@ -63,7 +63,7 @@ for dummyID,tmpList in tmpListList:
         jobBroker.setTestMode(taskSpec.vo,taskSpec.prodSourceLabel)
         splitter = JobSplitter()
         gen = JobGeneratorThread(None,threadPool,tbIF,ddmIF,siteMapper,False,taskSetupper,None,
-                                 None,None,None,brokerageLockIDs)
+                                 None,None,None,brokerageLockIDs, False)
 
         taskParamMap = None
         if taskSpec.useLimitedSites():


### PR DESCRIPTION
Network weight for the output files from satellite to nucleus
- Skip links with >300 files in the queue or blacklisted in AGIS
- For urgent jobs, skip links with network connectivity <1.7
- Calculate network weight from output files nqueued in the link and a manual classification of dynamic throughput (first available of 1h, 1d or 1w). If no dynamic throughput is available, take the AGIS closeness, which is based on the last month.
