### PR TITLE
improve job brokerage for ES at jobseed=all sites

### DIFF
--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -1080,6 +1080,14 @@ class AtlasProdJobBroker (JobBrokerBase):
             nActivated = AtlasBrokerUtils.getNumJobs(jobStatPrioMap, tmpSiteName, 'activated', None, wq_tag) + \
                          AtlasBrokerUtils.getNumJobs(jobStatPrioMap, tmpSiteName, 'throttled', None, wq_tag)
             nStarting  = AtlasBrokerUtils.getNumJobs(jobStatPrioMap, tmpSiteName, 'starting', None, wq_tag)
+
+            if taskSpec.useEventService():
+                # nRunning   = AtlasBrokerUtils.getNumJobs(jobStatMap, tmpSiteName, 'running', None, taskSpec.gshare)
+                nDefined   = AtlasBrokerUtils.getNumJobs(jobStatMap, tmpSiteName, 'defined', None, taskSpec.gshare) + self.getLiveCount(tmpSiteName)
+                nAssigned  = AtlasBrokerUtils.getNumJobs(jobStatMap, tmpSiteName, 'assigned', None, taskSpec.gshare)
+                nActivated = AtlasBrokerUtils.getNumJobs(jobStatMap, tmpSiteName, 'activated', None, taskSpec.gshare)
+                             AtlasBrokerUtils.getNumJobs(jobStatMap, tmpSiteName, 'throttled', None, taskSpec.gshare)
+                nStarting  = AtlasBrokerUtils.getNumJobs(jobStatMap, tmpSiteName, 'starting', None, taskSpec.gshare)
             if tmpSiteName in nPilotMap:
                 nPilot = nPilotMap[tmpSiteName]
             else:


### PR DESCRIPTION
In previous es tests, a lot of es jobs were activated at some jobseed=all sites while at the same time there were many activated high priority mc16 simul jobs. It happened because eventservice is using the same share as mc16 simul but with different WQ. The eventservice WQ doesn't know jobs with the same gshare but different WQ.

The updates: if it's an eventservice task, keep the same nRunning. But getNumJObs from the gshare, not the WQ.