### PR TITLE
add HPO msg consumer

### DIFF
--- a/pandajedi/jedicore/JediTaskBuffer.py
+++ b/pandajedi/jedicore/JediTaskBuffer.py
@@ -719,9 +719,8 @@ class JediTaskBuffer(TaskBuffer.TaskBuffer, CommandReceiveInterface):
     def getUsageBreakdown_JEDI(self, prod_source_label='user'):
         with self.proxyPool.get() as proxy:
             return proxy.getUsageBreakdown_JEDI(prod_source_label)
-    # get usage breakdown by users and sites
 
     # insert HPO pseudo event according to message from idds
-    def insertHpoEventAboutIdds_JEDI(self, jedi_task_id, start_number, end_number):
+    def insertHpoEventAboutIdds_JEDI(self, jedi_task_id, event_id_list):
         with self.proxyPool.get() as proxy:
-            return proxy.insertHpoEventAboutIdds_JEDI(jedi_task_id, start_number, end_number)
+            return proxy.insertHpoEventAboutIdds_JEDI(jedi_task_id, event_id_list)

--- a/pandajedi/jedicore/JediTaskBuffer.py
+++ b/pandajedi/jedicore/JediTaskBuffer.py
@@ -719,3 +719,9 @@ class JediTaskBuffer(TaskBuffer.TaskBuffer, CommandReceiveInterface):
     def getUsageBreakdown_JEDI(self, prod_source_label='user'):
         with self.proxyPool.get() as proxy:
             return proxy.getUsageBreakdown_JEDI(prod_source_label)
+    # get usage breakdown by users and sites
+
+    # insert HPO pseudo event according to message from idds
+    def insertHpoEventAboutIdds_JEDI(self, jedi_task_id, start_number, end_number):
+        with self.proxyPool.get() as proxy:
+            return proxy.insertHpoEventAboutIdds_JEDI(jedi_task_id, start_number, end_number)

--- a/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
@@ -44,7 +44,7 @@ class AtlasIddsMsgProcPlugin(BaseMsgProcPlugin):
         try:
             if msg_type in ('file_stagein', 'collection_stagein'):
                 self.plugin_TapeCarousel.process(msg_obj, decoded_data=msg_dict)
-            elif msg_type in ('file_hyperparameteropt', 'collection_hpyerparameteropt'):
+            elif msg_type in ('file_hyperparameteropt', 'collection_hyperparameteropt'):
                 self.plugin_HPO.process(msg_obj, decoded_data=msg_dict)
             else:
                 raise ValueError('invalid msg_type value: {0}'.format(msg_type))

--- a/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
@@ -1,0 +1,50 @@
+import json
+
+from pandajedi.jedimsgprocessor.base_msg_processor import BaseMsgProcPlugin
+from pandajedi.jedimsgprocessor.tape_carousel_msg_processor import TapeCarouselMsgProcPlugin
+from pandajedi.jedimsgprocessor.hpo_msg_processor import HPOMsgProcPlugin
+
+from pandacommon.pandalogger import logger_utils
+
+
+# logger
+base_logger = logger_utils.setup_logger(__name__.split('.')[-1])
+
+
+# Atlas iDDS message processing plugin, a bridge connect to other idds related message processing plugins
+class AtlasIddsMsgProcPlugin(BaseMsgProcPlugin):
+
+    def initialize(self):
+        super().initialize()
+        self.plugin_TapeCarousel = TapeCarouselMsgProcPlugin()
+        self.plugin_HPO = HPOMsgProcPlugin()
+
+    def process(self, msg_obj):
+        # logger
+        tmp_log = logger_utils.make_logger(base_logger, method_name='process')
+        # start
+        tmp_log.info('start')
+        tmp_log.debug('sub_id={0} ; msg_id={1}'.format(msg_obj.sub_id, msg_obj.msg_id))
+        # parse json
+        try:
+            msg_dict = json.loads(msg_obj.data)
+        except Exception as e:
+            err_str = 'failed to parse message json {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_obj.data)
+            tmp_log.error(err_str)
+            raise
+        # sanity check
+        try:
+            msg_type = msg_dict['msg_type']
+        except Exception as e:
+            err_str = 'failed to parse message object dict {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_dict)
+            tmp_log.error(err_str)
+            raise
+        # run different plugins according to message type
+        if msg_type in ('file_stagein', 'collection_stagein'):
+            self.plugin_TapeCarousel.process(msg_obj, decoded_data=msg_dict)
+        elif msg_type in ('file_hyperparameteropt', 'collection_hpyerparameteropt'):
+            self.plugin_HPO.process(msg_obj, decoded_data=msg_dict)
+        else:
+            raise ValueError('invalid msg_type value: {0}'.format(msg_type))
+        # done
+        tmp_log.info('done')

--- a/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
@@ -40,11 +40,14 @@ class AtlasIddsMsgProcPlugin(BaseMsgProcPlugin):
             tmp_log.error(err_str)
             raise
         # run different plugins according to message type
-        if msg_type in ('file_stagein', 'collection_stagein'):
-            self.plugin_TapeCarousel.process(msg_obj, decoded_data=msg_dict)
-        elif msg_type in ('file_hyperparameteropt', 'collection_hpyerparameteropt'):
-            self.plugin_HPO.process(msg_obj, decoded_data=msg_dict)
-        else:
-            raise ValueError('invalid msg_type value: {0}'.format(msg_type))
+        try:
+            if msg_type in ('file_stagein', 'collection_stagein'):
+                self.plugin_TapeCarousel.process(msg_obj, decoded_data=msg_dict)
+            elif msg_type in ('file_hyperparameteropt', 'collection_hpyerparameteropt'):
+                self.plugin_HPO.process(msg_obj, decoded_data=msg_dict)
+            else:
+                raise ValueError('invalid msg_type value: {0}'.format(msg_type))
+        except Exception:
+            raise
         # done
         tmp_log.info('done')

--- a/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/atlas_idds_msg_processor.py
@@ -15,9 +15,10 @@ base_logger = logger_utils.setup_logger(__name__.split('.')[-1])
 class AtlasIddsMsgProcPlugin(BaseMsgProcPlugin):
 
     def initialize(self):
-        super().initialize()
         self.plugin_TapeCarousel = TapeCarouselMsgProcPlugin()
+        self.plugin_TapeCarousel.initialize()
         self.plugin_HPO = HPOMsgProcPlugin()
+        self.plugin_HPO.initialize()
 
     def process(self, msg_obj):
         # logger

--- a/pandajedi/jedimsgprocessor/hpo_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/hpo_msg_processor.py
@@ -31,6 +31,9 @@ class HPOMsgProcPlugin(BaseMsgProcPlugin):
             jeditaskid = int(msg_dict['workload_id'])
             if msg_type == 'file_hyperparameteropt':
                 target_list = msg_dict['files']
+            elif msg_type == 'collection_hpyerparameteropt':
+                # to finish the task
+                pass
             else:
                 raise ValueError('invalid msg_type value: {0}'.format(msg_type))
         except Exception as e:
@@ -38,7 +41,7 @@ class HPOMsgProcPlugin(BaseMsgProcPlugin):
             tmp_log.error(err_str)
             raise
         # run
-        if True:
+        if msg_type == 'file_hyperparameteropt':
             # insert HPO events
             try:
                 # map
@@ -58,7 +61,7 @@ class HPOMsgProcPlugin(BaseMsgProcPlugin):
                 err_str = 'failed to parse message object, skipped. {0} : {1}'.format(e.__class__.__name__, e)
                 tmp_log.error(err_str)
                 raise
-        elif False:
+        elif msg_type == 'collection_hpyerparameteropt':
             # finish the task
             try:
 

--- a/pandajedi/jedimsgprocessor/hpo_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/hpo_msg_processor.py
@@ -38,25 +38,44 @@ class HPOMsgProcPlugin(BaseMsgProcPlugin):
             tmp_log.error(err_str)
             raise
         # run
-        try:
-            # map
-            scope_name_list_map = {}
-            # loop over targets
-            for target in target_list:
-                the_id = target['name']
-                # parameter, loss = json.loads(target['path'])
+        if True:
+            # insert HPO events
+            try:
+                # map
+                scope_name_list_map = {}
+                # event ids from the targets
+                event_id_list = [ target['name'] for target in target_list ]
+                n_events = len(event_id_list)
                 # insert events
                 res = self.tbIF.insertHpoEventAboutIdds_JEDI(   jedi_task_id=jeditaskid,
-                                                                start_number=the_id,
-                                                                end_number=the_id)
+                                                                event_id_list=event_id_list)
                 # check if ok
                 if res:
-                    tmp_log.debug('jeditaskid={0}, id={1}, event inserted'.format(jeditaskid, the_id))
+                    tmp_log.debug('jeditaskid={0}, inserted {1} events: {2}'.format(jeditaskid, n_events, event_id_list))
                 else:
-                    tmp_log.warning('jeditaskid={0}, id={1}, event not inserted'.format(jeditaskid, the_id))
-        except Exception as e:
-            err_str = 'failed to parse message object, skipped. {0} : {1}'.format(e.__class__.__name__, e)
-            tmp_log.error(err_str)
-            raise
+                    tmp_log.warning('jeditaskid={0}, failed to insert events: {1}'.format(jeditaskid, event_id_list))
+            except Exception as e:
+                err_str = 'failed to parse message object, skipped. {0} : {1}'.format(e.__class__.__name__, e)
+                tmp_log.error(err_str)
+                raise
+        elif False:
+            # finish the task
+            try:
+
+                # send finish command
+                retVal, retStr = self.tbIF.sendCommandTaskPanda(jeditaskid,
+                                                                'JEDI. HPO task finished',
+                                                                True,
+                                                                'finish',
+                                                                comQualifier='soft')
+                # check if ok
+                if retVal:
+                    tmp_log.debug('jeditaskid={0}, finished the task'.format(jeditaskid))
+                else:
+                    tmp_log.warning('jeditaskid={0}, failed finish the task: {1}'.format(jeditaskid, retStr))
+            except Exception as e:
+                err_str = 'failed to parse message object, skipped. {0} : {1}'.format(e.__class__.__name__, e)
+                tmp_log.error(err_str)
+                raise
         # done
         tmp_log.info('done')

--- a/pandajedi/jedimsgprocessor/hpo_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/hpo_msg_processor.py
@@ -1,0 +1,62 @@
+import json
+
+from pandajedi.jedimsgprocessor.base_msg_processor import BaseMsgProcPlugin
+
+from pandacommon.pandalogger import logger_utils
+
+
+# logger
+base_logger = logger_utils.setup_logger(__name__.split('.')[-1])
+
+
+# Hyper-Parameter-Optimization message processing plugin
+class HPOMsgProcPlugin(BaseMsgProcPlugin):
+
+    def process(self, msg_obj):
+        # logger
+        tmp_log = logger_utils.make_logger(base_logger, method_name='process')
+        # start
+        tmp_log.info('start')
+        tmp_log.debug('sub_id={0} ; msg_id={1}'.format(msg_obj.sub_id, msg_obj.msg_id))
+        # parse json
+        try:
+            msg_dict = json.loads(msg_obj.data)
+        except Exception as e:
+            err_str = 'failed to parse message json {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_obj.data)
+            tmp_log.error(err_str)
+            raise
+        # sanity check
+        try:
+            msg_type = msg_dict['msg_type']
+            jeditaskid = int(msg_dict['workload_id'])
+            if msg_type == 'file_hyperparameteropt':
+                target_list = msg_dict['files']
+            else:
+                raise ValueError('invalid msg_type value: {0}'.format(msg_type))
+        except Exception as e:
+            err_str = 'failed to parse message object dict {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_dict)
+            tmp_log.error(err_str)
+            raise
+        # run
+        try:
+            # map
+            scope_name_list_map = {}
+            # loop over targets
+            for target in target_list:
+                the_id = target['name']
+                # parameter, loss = json.loads(target['path'])
+                # insert events
+                res = self.tbIF.insertHpoEventAboutIdds_JEDI(   jedi_task_id=jeditaskid,
+                                                                start_number=the_id,
+                                                                end_number=the_id)
+                # check if ok
+                if res:
+                    tmp_log.debug('jeditaskid={0}, id={1}, event inserted'.format(jeditaskid, the_id))
+                else:
+                    tmp_log.warning('jeditaskid={0}, id={1}, event not inserted'.format(jeditaskid, the_id))
+        except Exception as e:
+            err_str = 'failed to parse message object, skipped. {0} : {1}'.format(e.__class__.__name__, e)
+            tmp_log.error(err_str)
+            raise
+        # done
+        tmp_log.info('done')

--- a/pandajedi/jedimsgprocessor/hpo_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/hpo_msg_processor.py
@@ -35,7 +35,7 @@ class HPOMsgProcPlugin(BaseMsgProcPlugin):
             jeditaskid = int(msg_dict['workload_id'])
             if msg_type == 'file_hyperparameteropt':
                 target_list = msg_dict['files']
-            elif msg_type == 'collection_hpyerparameteropt':
+            elif msg_type == 'collection_hyperparameteropt':
                 # to finish the task
                 pass
             else:
@@ -65,7 +65,7 @@ class HPOMsgProcPlugin(BaseMsgProcPlugin):
                 err_str = 'failed to parse message object, skipped. {0} : {1}'.format(e.__class__.__name__, e)
                 tmp_log.error(err_str)
                 raise
-        elif msg_type == 'collection_hpyerparameteropt':
+        elif msg_type == 'collection_hyperparameteropt':
             # finish the task
             try:
 

--- a/pandajedi/jedimsgprocessor/hpo_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/hpo_msg_processor.py
@@ -12,19 +12,23 @@ base_logger = logger_utils.setup_logger(__name__.split('.')[-1])
 # Hyper-Parameter-Optimization message processing plugin
 class HPOMsgProcPlugin(BaseMsgProcPlugin):
 
-    def process(self, msg_obj):
+    def process(self, msg_obj, decoded_data=None):
         # logger
         tmp_log = logger_utils.make_logger(base_logger, method_name='process')
         # start
         tmp_log.info('start')
         tmp_log.debug('sub_id={0} ; msg_id={1}'.format(msg_obj.sub_id, msg_obj.msg_id))
-        # parse json
-        try:
-            msg_dict = json.loads(msg_obj.data)
-        except Exception as e:
-            err_str = 'failed to parse message json {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_obj.data)
-            tmp_log.error(err_str)
-            raise
+        # parse
+        if decoded_data is None:
+            # json decode
+            try:
+                msg_dict = json.loads(msg_obj.data)
+            except Exception as e:
+                err_str = 'failed to parse message json {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_obj.data)
+                tmp_log.error(err_str)
+                raise
+        else:
+            msg_dict = decoded_data
         # sanity check
         try:
             msg_type = msg_dict['msg_type']

--- a/pandajedi/jedimsgprocessor/tape_carousel_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/tape_carousel_msg_processor.py
@@ -12,19 +12,23 @@ base_logger = logger_utils.setup_logger(__name__.split('.')[-1])
 # Tape carousel message processing plugin
 class TapeCarouselMsgProcPlugin(BaseMsgProcPlugin):
 
-    def process(self, msg_obj):
+    def process(self, msg_obj, decoded_data=None):
         # logger
         tmp_log = logger_utils.make_logger(base_logger, method_name='process')
         # start
         tmp_log.info('start')
         tmp_log.debug('sub_id={0} ; msg_id={1}'.format(msg_obj.sub_id, msg_obj.msg_id))
-        # parse json
-        try:
-            msg_dict = json.loads(msg_obj.data)
-        except Exception as e:
-            err_str = 'failed to parse message json {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_obj.data)
-            tmp_log.error(err_str)
-            raise
+        # parse
+        if decoded_data is None:
+            # json decode
+            try:
+                msg_dict = json.loads(msg_obj.data)
+            except Exception as e:
+                err_str = 'failed to parse message json {2} , skipped. {0} : {1}'.format(e.__class__.__name__, e, msg_obj.data)
+                tmp_log.error(err_str)
+                raise
+        else:
+            msg_dict = decoded_data
         # sanity check
         try:
             msg_type = msg_dict['msg_type']

--- a/pandajedi/jeditest/addHpoTask.py
+++ b/pandajedi/jeditest/addHpoTask.py
@@ -1,0 +1,52 @@
+import uuid
+
+from userinterface import Client
+
+taskParamMap = {}
+
+taskParamMap['noInput'] = True
+taskParamMap['nEventsPerJob'] = 1
+taskParamMap['nEvents'] = 5
+taskParamMap['taskName'] = str(uuid.uuid4())
+taskParamMap['userName'] = 'pandasrv1'
+taskParamMap['vo'] = 'atlas'
+taskParamMap['taskPriority'] = 1000
+taskParamMap['reqID'] = 12345
+taskParamMap['architecture'] = 'power9'
+taskParamMap['hpoWorkflow'] = True
+taskParamMap['transUses'] = 'some_A'
+taskParamMap['transHome'] = 'some_B'
+taskParamMap['transPath'] = 'training.py'
+taskParamMap['processingType'] = 'simul'
+taskParamMap['prodSourceLabel'] = 'test'
+taskParamMap['taskType'] = 'prod'
+taskParamMap['workingGroup'] = 'AP_HPO'
+taskParamMap['coreCount'] = 1
+taskParamMap['site'] = 'BNL_PROD_UCORE'
+taskParamMap['nucleus'] = 'CERN-PROD'
+taskParamMap['cloud'] = 'WORLD'
+#taskParamMap['mergeOutput'] = True
+logDatasetName = 'panda.jeditest.log.{0}'.format(uuid.uuid4())
+taskParamMap['log'] = {'dataset': logDatasetName,
+                       'type':'template',
+                       'param_type':'log',
+                       'token': 'ddd:.*DATADISK',
+                       'destination':'type=DATADISK,s3=1',
+                       'offset':1000,
+                       'value':'{0}.${{SN}}.log.tgz'.format(logDatasetName)}
+taskParamMap['jobParameters'] = [
+    {'type':'constant',
+     'value': 'some args'
+     },
+    {'type':'constant',
+     'value':'AMITag=p1462'
+     },
+    {'type':'template',
+     'param_type':'input',
+     'value':'ds=${IN_DATA}',
+     'dataset':'mc16_13TeV.398184.MGPy8EG_A14N23LO_SlepSlep_direct_150p0_130p0.simul.HITS.e7506_e5984_a875_tid18097791_00',
+     'attributes': 'nosplit,repeat',
+     },
+    ]
+
+print(Client.insertTaskParams(taskParamMap))


### PR DESCRIPTION
Not sure if I understand correctly...


- '''_Basically startEvent = endEvent = the "id_"''' (from mail) - Does it mean to insert only one event for each HPO message? Then what about ["_nEvents = # of HP samples to be evaluated_"](https://docs.google.com/presentation/d/1O1b7M_w9qpB6YJydIsJdYNnRNHESUAJHARDlMGppQyI/edit#slide=id.g7fdab89324_0_11)?
- Need other change in the db proxy method?
- Is it correct to ignore parameter and loss from the message [here](https://github.com/PanDAWMS/panda-jedi/compare/flin?expand=1#diff-c1c8af32091bda17b417c18ca5893a2bR47)? Nowhere in the event table to put them into.
- ["_The task is finished when iDDS sends a message_"](https://docs.google.com/presentation/d/1O1b7M_w9qpB6YJydIsJdYNnRNHESUAJHARDlMGppQyI/edit#slide=id.g7fdab89324_0_11) - Who to receive this message and made the task finished? Do we need another functionality in JEDI message consumer?
- This code may not work, depending on how the message broker of iDDS will be set. If iDDS sends both tape carousel and HPO messages to the same message queue, then both JEDI plugin need to be changed. Otherwise, (separate message queues, which I prefer) it's fine.