### PR TITLE
more strict checks in analy job broker; compute to-running rate of sites

### DIFF
--- a/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
@@ -819,7 +819,7 @@ class AtlasAnalJobBroker(JobBrokerBase):
                 # send info to logger
                 self.sendLogMessage(tmpLog)
                 return retTmpError
-            tmpSt, siteToRunRateMap = self.taskBufferIF.getSiteToRunRateStats(taskSpec.vo)
+            tmpSt, siteToRunRateMap = AtlasBrokerUtils.getSiteToRunRateStats(tbIF=self.taskBufferIF, vo=taskSpec.vo)
             if not tmpSt:
                 tmpLog.warning('failed to get site to-running rate')
             # check for preassigned
@@ -1058,7 +1058,12 @@ class AtlasAnalJobBroker(JobBrokerBase):
             # calculate weight
             orig_weight = float(nRunning + 1) / float(nActivated + nAssigned + nDefined + nStarting + 1)
             weight = orig_weight
-            to_running_rate = siteToRunRateMap[tmpSiteName][taskSpec.gshare]
+            try:
+                to_running_rate = siteToRunRateMap[tmpSiteName][taskSpec.gshare]
+            except KeyError:
+                to_running_rate_str = 'unknown'
+            else:
+                to_running_rate_str = '{0:.3f}'.format(to_running_rate)
             nThrottled = 0
             if tmpSiteName in remoteSourceList:
                 nThrottled = AtlasBrokerUtils.getNumJobs(jobStatPrioMap, tmpSiteName, 'throttled', workQueue_tag=taskSpec.gshare)
@@ -1102,7 +1107,7 @@ class AtlasAnalJobBroker(JobBrokerBase):
                                                                                 nFinished,
                                                                                 tmpDataWeight)
             tmpStr += 'totalInGB={0} localInGB={1} nFiles={2} '.format(totalSize, localSize, totalNumFiles)
-            tmpStr += 'toRunningRate={0:.3f} '.format(to_running_rate)
+            tmpStr += 'toRunningRate={0} '.format(to_running_rate_str)
             weightStr[tmpPseudoSiteName] = tmpStr
             # append
             if tmpSiteName in sitesUsedByTask:

--- a/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
@@ -821,7 +821,11 @@ class AtlasAnalJobBroker(JobBrokerBase):
                 return retTmpError
             tmpSt, siteToRunRateMap = AtlasBrokerUtils.getSiteToRunRateStats(tbIF=self.taskBufferIF, vo=taskSpec.vo)
             if not tmpSt:
-                tmpLog.warning('failed to get site to-running rate')
+                tmpLog.error('failed to get site to-running rate')
+                taskSpec.setErrDiag(tmpLog.uploadLog(taskSpec.jediTaskID))
+                # send info to logger
+                self.sendLogMessage(tmpLog)
+                return retTmpError
             # check for preassigned
             if sitePreAssigned:
                 if preassignedSite not in scanSiteList and preassignedSite not in self.get_unified_sites(scanSiteList):

--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -666,10 +666,10 @@ def getSiteToRunRateStats(tbIF, vo, time_window=21600, cutoff=300):
         ret_val = True
         ret_map = CACHE_SiteToRunRateStats[cache_key]['data']
     else:
-        # query from DB cache
-        cached_data = tbIF.getCachedData(key='SiteToRunRateStats')
-        expired_time = cached_data.modificationTime + current_time + datetime.timedelta(seconds=600)
         if False:
+        # query from DB cache
+        # cached_data = tbIF.getCachedData(key='SiteToRunRateStats')
+        # expired_time = cached_data.modificationTime + current_time + datetime.timedelta(seconds=600)
         # if current_time >= expired_time:
         #     # valid DB cache
         #     ret_val = True

--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -524,7 +524,7 @@ def getDictToSetNucleus(nucleusSpec,tmpDatasetSpecs):
         if endPoint is None:
             continue
         token = endPoint['ddm_endpoint_name']
-        # add origianl token
+        # add original token
         if datasetSpec.storageToken not in ['',None]:
             token += '/{0}'.format(datasetSpec.storageToken.split('/')[-1])
         retMap['datasets'].append({'datasetID':datasetSpec.datasetID,
@@ -677,50 +677,61 @@ def getSiteToRunRateStats(tbIF, vo, time_window=21600, cutoff=300, cache_lifetim
     else:
         # try some times
         for _ in range(99):
-            # query from DB cache
-            cache_spec = tbIF.getCache_JEDI(main_key=dc_main_key, sub_key=dc_sub_key)
-            if cache_spec is not None:
-                expired_time = cache_spec.last_update + datetime.timedelta(seconds=cache_lifetime)
-                if current_time <= expired_time:
-                    # valid DB cache
-                    ret_val = True
-                    ret_map = cache_spec.data
+            # skip if too long after original current time
+            if datetime.datetime.utcnow() - current_time > datetime.timedelta(seconds=min(10, cache_lifetime/4)):
+                # break trying
+                break
+            try:
+                # query from DB cache
+                cache_spec = tbIF.getCache_JEDI(main_key=dc_main_key, sub_key=dc_sub_key)
+                if cache_spec is not None:
+                    expired_time = cache_spec.last_update + datetime.timedelta(seconds=cache_lifetime)
+                    if current_time <= expired_time:
+                        # valid DB cache
+                        ret_val = True
+                        ret_map = json.loads(cache_spec.data)
+                        # fill local cache
+                        CACHE_SiteToRunRateStats[local_cache_key] = {   'exp': expired_time,
+                                                                        'data': ret_map}
+                        # break trying
+                        break
+                # got process lock
+                got_lock = tbIF.lockProcess_JEDI(   vo=vo, prodSourceLabel=this_prodsourcelabel,
+                                                    cloud=None, workqueue_id=None,
+                                                    resource_name=None,
+                                                    component=this_component,
+                                                    pid=this_pid, timeLimit=5)
+                if not got_lock:
+                    # not getting lock, sleep and query cache again
+                    time.sleep(1)
+                    continue
+                # query from PanDA DB directly
+                ret_val, ret_map = tbIF.getSiteToRunRateStats(  vo=vo, exclude_rwq=False,
+                                                                starttime_min=starttime_min,
+                                                                starttime_max=starttime_max)
+                if ret_val:
+                    # expired time
+                    expired_time = current_time + datetime.timedelta(seconds=cache_lifetime)
                     # fill local cache
                     CACHE_SiteToRunRateStats[local_cache_key] = {   'exp': expired_time,
                                                                     'data': ret_map}
-                    # break trying
-                    break
-            # got process lock
-            got_lock = tbIF.lockProcess_JEDI(   vo=vo, prodSourceLabel=this_prodsourcelabel,
-                                                cloud=None, workqueue_id=None,
-                                                resource_name=None,
-                                                component=this_component,
-                                                pid=this_pid, timeLimit=5)
-            if not got_lock:
-                # not getting lock, sleep and query cache again
-                time.sleep(1)
-                continue
-            # query from PanDA DB directly
-            ret_val, ret_map = tbIF.getSiteToRunRateStats(  vo=vo, exclude_rwq=False,
-                                                            starttime_min=starttime_min,
-                                                            starttime_max=starttime_max)
-            if ret_val:
-                # expired time
-                expired_time = current_time + datetime.timedelta(seconds=cache_lifetime)
-                # fill local cache
-                CACHE_SiteToRunRateStats[local_cache_key] = {   'exp': expired_time,
-                                                                'data': ret_map}
-                # json of data
-                data_json = json.dumps(ret_map)
-                # fill DB cache
-                tbIF.updateCache_JEDI(main_key=dc_main_key, sub_key=dc_sub_key, data=data_json)
-            # unlock process
-            tbIF.unlockProcess_JEDI(vo=vo, prodSourceLabel=this_prodsourcelabel,
-                                    cloud=None, workqueue_id=None,
-                                    resource_name=None,
-                                    component=this_component, pid=this_pid)
-            # break trying
-            break
+                    # json of data
+                    data_json = json.dumps(ret_map)
+                    # fill DB cache
+                    tbIF.updateCache_JEDI(main_key=dc_main_key, sub_key=dc_sub_key, data=data_json)
+                # unlock process
+                tbIF.unlockProcess_JEDI(vo=vo, prodSourceLabel=this_prodsourcelabel,
+                                        cloud=None, workqueue_id=None,
+                                        resource_name=None,
+                                        component=this_component, pid=this_pid)
+                # break trying
+                break
+            except Exception as e:
+                # dump error message
+                err_str = 'AtlasBrokerUtils.getSiteToRunRateStats got {0}: {1} \n'.format(e.__class__.__name__, e)
+                sys.stderr.write(err_str)
+                # break trying
+                break
     # return
     return ret_val, ret_map
 

--- a/pandajedi/jedibrokerage/AtlasProdTaskBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdTaskBroker.py
@@ -86,7 +86,7 @@ class AtlasProdTaskBroker (TaskBrokerBase):
                         # use default endpoint
                         if token is None:
                             token = siteSpec.ddm_output[scopeSiteSpec_output]
-                        # add origianl token
+                        # add original token
                         if datasetSpec.storageToken not in ['',None]:
                             token += '/{0}'.format(datasetSpec.storageToken)
                         retMap[tmpTaskID]['datasets'].append({'datasetID':datasetSpec.datasetID,

--- a/pandajedi/jedicore/JediCacheSpec.py
+++ b/pandajedi/jedicore/JediCacheSpec.py
@@ -54,6 +54,7 @@ class JediCacheSpec(object):
         return ret
 
     # return an expression of bind variables for UPDATE
-    def bindUpdateChangesExpression(self):
+    @classmethod
+    def bindUpdateChangesExpression(cls):
         ret = ','.join([ '{0}=:{0}'.format(attr) for attr in cls.attributes ])
         return ret

--- a/pandajedi/jedicore/JediCacheSpec.py
+++ b/pandajedi/jedicore/JediCacheSpec.py
@@ -1,0 +1,59 @@
+import re
+
+from six import iteritems
+
+
+"""
+cache specification for JEDI
+
+"""
+class JediCacheSpec(object):
+    # attributes
+    attributes = (
+            'main_key',
+            'sub_key',
+            'data',
+            'last_update',
+        )
+
+    # constructor
+    def __init__(self):
+        # install attributes
+        for attr in self.attributes:
+            object.__setattr__(self, attr, None)
+
+    # return map of values
+    def valuesMap(self):
+        ret = {}
+        for attr in self.attributes:
+            val = getattr(self, attr)
+            ret[':%s' % attr] = val
+        return ret
+
+    # pack tuple into JediCacheSpec
+    def pack(self, values):
+        for i, attr in enumerate(self.attributes):
+            val = values[i]
+            object.__setattr__(self, attr, val)
+
+    # return column names for INSERT
+    @classmethod
+    def columnNames(cls, prefix=None):
+        ret = ''
+        if prefix is None:
+            ret = ','.join(cls.attributes)
+        else:
+            ret = ','.join([ '{0}.{1}'.format(prefix, attr) for attr in cls.attributes ])
+        return ret
+
+    # return expression of bind variables for INSERT
+    @classmethod
+    def bindValuesExpression(cls):
+        values_str = ','.join([ ':{0}'.format(attr) for attr in cls.attributes ])
+        ret = 'VALUES({0})'.format(values_str)
+        return ret
+
+    # return an expression of bind variables for UPDATE
+    def bindUpdateChangesExpression(self):
+        ret = ','.join([ '{0}=:{0}'.format(attr) for attr in cls.attributes ])
+        return ret

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -13226,7 +13226,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
             return False
 
 
-        # get event statistics
+    # get event statistics
     def get_event_statistics(self, jedi_task_id):
         comment = ' /* JediDBProxy.get_event_statistics */'
         methodName = self.getMethodName(comment)

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -13259,103 +13259,103 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
             return False, {}
 
 
-# update cache
-def updateCache_JEDI(self, main_key, sub_key, data):
-    comment = ' /* JediDBProxy.updateCache_JEDI */'
-    methodName = self.getMethodName(comment)
-    # defaults
-    if sub_key is None:
-        sub_key = 'default'
-    # last update time
-    last_update = datetime.datetime.utcnow()
-    last_update_str = last_update.strftime('%Y-%m-%d_%H:%M:%S')
-    methodName += " <main_key={0} sub_key={1} last_update={2}>".format(main_key, sub_key, last_update_str)
-    tmpLog = MsgWrapper(logger, methodName)
-    tmpLog.debug('start')
-    try:
-        retVal = False
-        # sql to check
-        sqlC = ("SELECT last_update "
-                "FROM {0}.Cache "
-                "WHERE main_key=:main_key AND sub_key=:sub_key "
-            ).format(jedi_config.db.schemaJEDI)
-        # sql to insert
-        sqlI = ("INSERT INTO {0}.Cache "
-                "({1}) {2} "
-            ).format(   jedi_config.db.schemaJEDI,
-                        JediCacheSpec.columnNames(),
-                        JediCacheSpec.bindValuesExpression())
-        # sql to update
-        sqlU = ("UPDATE {0}.Cache "
-                "SET {1} "
-                "WHERE main_key=:main_key AND sub_key=:sub_key "
-            ).format(jedi_config.db.schemaJEDI, JediCacheSpec.bindUpdateChangesExpression())
-        # start transaction
-        self.conn.begin()
-        # check
-        varMap = {}
-        varMap[':main_key'] = main_key
-        varMap[':sub_key'] = sub_key
-        self.cur.execute(sqlC+comment, varMap)
-        resC = self.cur.fetchone()
-        varMap[':data'] = data
-        varMap[':last_update'] = last_update
-        if resC is None:
-            # insert if missing
-            tmpLog.debug('insert')
-            self.cur.execute(sqlI+comment, varMap)
-        else:
-            # update
-            tmpLog.debug('update')
-            self.cur.execute(sqlU+comment, varMap)
-        # commit
-        if not self._commit():
-            raise RuntimeError('Commit error')
-        # return
-        retVal = True
-        tmpLog.debug('done')
-        return retVal
-    except Exception:
-        # roll back
-        self._rollback()
-        # error
-        self.dumpErrorMessage(tmpLog,msgType='debug')
-        return retVal
+    # update cache
+    def updateCache_JEDI(self, main_key, sub_key, data):
+        comment = ' /* JediDBProxy.updateCache_JEDI */'
+        methodName = self.getMethodName(comment)
+        # defaults
+        if sub_key is None:
+            sub_key = 'default'
+        # last update time
+        last_update = datetime.datetime.utcnow()
+        last_update_str = last_update.strftime('%Y-%m-%d_%H:%M:%S')
+        methodName += " <main_key={0} sub_key={1} last_update={2}>".format(main_key, sub_key, last_update_str)
+        tmpLog = MsgWrapper(logger, methodName)
+        tmpLog.debug('start')
+        try:
+            retVal = False
+            # sql to check
+            sqlC = ("SELECT last_update "
+                    "FROM {0}.Cache "
+                    "WHERE main_key=:main_key AND sub_key=:sub_key "
+                ).format(jedi_config.db.schemaJEDI)
+            # sql to insert
+            sqlI = ("INSERT INTO {0}.Cache "
+                    "({1}) {2} "
+                ).format(   jedi_config.db.schemaJEDI,
+                            JediCacheSpec.columnNames(),
+                            JediCacheSpec.bindValuesExpression())
+            # sql to update
+            sqlU = ("UPDATE {0}.Cache "
+                    "SET {1} "
+                    "WHERE main_key=:main_key AND sub_key=:sub_key "
+                ).format(jedi_config.db.schemaJEDI, JediCacheSpec.bindUpdateChangesExpression())
+            # start transaction
+            self.conn.begin()
+            # check
+            varMap = {}
+            varMap[':main_key'] = main_key
+            varMap[':sub_key'] = sub_key
+            self.cur.execute(sqlC+comment, varMap)
+            resC = self.cur.fetchone()
+            varMap[':data'] = data
+            varMap[':last_update'] = last_update
+            if resC is None:
+                # insert if missing
+                tmpLog.debug('insert')
+                self.cur.execute(sqlI+comment, varMap)
+            else:
+                # update
+                tmpLog.debug('update')
+                self.cur.execute(sqlU+comment, varMap)
+            # commit
+            if not self._commit():
+                raise RuntimeError('Commit error')
+            # return
+            retVal = True
+            tmpLog.debug('done')
+            return retVal
+        except Exception:
+            # roll back
+            self._rollback()
+            # error
+            self.dumpErrorMessage(tmpLog,msgType='debug')
+            return retVal
 
 
-# get cache
-def getCache_JEDI(self, main_key, sub_key):
-    comment = ' /* JediDBProxy.getCache_JEDI */'
-    methodName = self.getMethodName(comment)
-    # defaults
-    if sub_key is None:
-        sub_key = 'default'
-    methodName += " <main_key={0} sub_key={1}>".format(main_key, sub_key)
-    tmpLog = MsgWrapper(logger, methodName)
-    tmpLog.debug('start')
-    try:
-        retVal = False
-        # sql to get
-        sqlC = ("SELECT {1} "
-                "FROM {0}.Cache "
-                "WHERE main_key=:main_key AND sub_key=:sub_key "
-            ).format(jedi_config.db.schemaJEDI, JediCacheSpec.columnNames())
-        # check
-        varMap = {}
-        varMap[':main_key'] = main_key
-        varMap[':sub_key'] = sub_key
-        self.cur.execute(sqlC+comment, varMap)
-        resC = self.cur.fetchone()
-        if resC is None:
-            tmpLog.debug('got nothing, skipped')
-            return None
-        cache_spec = JediCacheSpec()
-        cache_spec.pack(resC)
-        tmpLog.debug('got cache, done')
-        # return
-        return cache_spec
-    except Exception:
-        # roll back
-        self._rollback()
-        # error
-        self.dumpErrorMessage(tmpLog,msgType='debug')
+    # get cache
+    def getCache_JEDI(self, main_key, sub_key):
+        comment = ' /* JediDBProxy.getCache_JEDI */'
+        methodName = self.getMethodName(comment)
+        # defaults
+        if sub_key is None:
+            sub_key = 'default'
+        methodName += " <main_key={0} sub_key={1}>".format(main_key, sub_key)
+        tmpLog = MsgWrapper(logger, methodName)
+        tmpLog.debug('start')
+        try:
+            retVal = False
+            # sql to get
+            sqlC = ("SELECT {1} "
+                    "FROM {0}.Cache "
+                    "WHERE main_key=:main_key AND sub_key=:sub_key "
+                ).format(jedi_config.db.schemaJEDI, JediCacheSpec.columnNames())
+            # check
+            varMap = {}
+            varMap[':main_key'] = main_key
+            varMap[':sub_key'] = sub_key
+            self.cur.execute(sqlC+comment, varMap)
+            resC = self.cur.fetchone()
+            if resC is None:
+                tmpLog.debug('got nothing, skipped')
+                return None
+            cache_spec = JediCacheSpec()
+            cache_spec.pack(resC)
+            tmpLog.debug('got cache, done')
+            # return
+            return cache_spec
+        except Exception:
+            # roll back
+            self._rollback()
+            # error
+            self.dumpErrorMessage(tmpLog,msgType='debug')

--- a/pandajedi/jedicore/JediTaskBuffer.py
+++ b/pandajedi/jedicore/JediTaskBuffer.py
@@ -724,3 +724,8 @@ class JediTaskBuffer(TaskBuffer.TaskBuffer, CommandReceiveInterface):
     def insertHpoEventAboutIdds_JEDI(self, jedi_task_id, event_id_list):
         with self.proxyPool.get() as proxy:
             return proxy.insertHpoEventAboutIdds_JEDI(jedi_task_id, event_id_list)
+
+    # get site to-running rate statistics by global share
+    def getSiteToRunRateStats(self, vo, exclude_rwq=False, time_window=6):
+        with self.proxyPool.get() as proxy:
+            return proxy.getSiteToRunRateStats(vo, exclude_rwq, time_window)

--- a/pandajedi/jedicore/JediTaskBuffer.py
+++ b/pandajedi/jedicore/JediTaskBuffer.py
@@ -726,6 +726,6 @@ class JediTaskBuffer(TaskBuffer.TaskBuffer, CommandReceiveInterface):
             return proxy.insertHpoEventAboutIdds_JEDI(jedi_task_id, event_id_list)
 
     # get site to-running rate statistics by global share
-    def getSiteToRunRateStats(self, vo, exclude_rwq=False, time_window=6):
+    def getSiteToRunRateStats(self, vo, exclude_rwq, starttime_min, starttime_max):
         with self.proxyPool.get() as proxy:
-            return proxy.getSiteToRunRateStats(vo, exclude_rwq, time_window)
+            return proxy.getSiteToRunRateStats(vo, exclude_rwq, starttime_min, starttime_max)

--- a/pandajedi/jedicore/JediTaskBuffer.py
+++ b/pandajedi/jedicore/JediTaskBuffer.py
@@ -729,3 +729,13 @@ class JediTaskBuffer(TaskBuffer.TaskBuffer, CommandReceiveInterface):
     def getSiteToRunRateStats(self, vo, exclude_rwq, starttime_min, starttime_max):
         with self.proxyPool.get() as proxy:
             return proxy.getSiteToRunRateStats(vo, exclude_rwq, starttime_min, starttime_max)
+
+    # update cache
+    def updateCache_JEDI(self, main_key, sub_key, data):
+        with self.proxyPool.get() as proxy:
+            return proxy.updateCache_JEDI(main_key, sub_key, data)
+
+    # get cache
+    def getCache_JEDI(self, main_key, sub_key):
+        with self.proxyPool.get() as proxy:
+            return proxy.getCache_JEDI(main_key, sub_key)


### PR DESCRIPTION
The idea is to make analy broker more strict to filter out bad sites. I discussed with Fernando about the idea.

E.g. This task was shown in my slow task report. Slowness was due to jobs stuck on ANALY_DCSC.
Although ANALY_DCSC had zero running jobs and behaved inactive, JEDI still brokered jobs to ANALY_DCSC at that time, since for some input files of the task, ANALY_DCSC was the only site that had the input files (WITH data locality) and also passed all checks:

```
2020-04-08 20:22:05,978 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702> start
2020-04-08 20:22:06,017 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> initial 433 candidates
2020-04-08 20:22:06,025 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702> !!! look for candidates WITH data locality check
2020-04-08 20:22:06,026 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702> getting the list of sites where user.cgottard:user.cgottard.HDBS3.data18_13TeV.periodF_EXT0.304432020 is available
2020-04-08 20:22:06,178 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702>  35 sites : ...
2020-04-08 20:22:06,180 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 18 candidates have input data
2020-04-08 20:22:06,180 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702>   skip site=ANALY_BOINC due to status=test criteria=-status
...
2020-04-08 20:22:06,605 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed memory check = 4350 MB
2020-04-08 20:22:06,606 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> maxAtomSize=219614246 effectiveAtomSize=209.44046592712402 outDiskCount=101376 workDiskSize=2101346304
2020-04-08 20:22:06,606 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> minDiskCountScratch=2233.0 minDiskCountRemote=2024.0 nGBPerJobInMB=None
2020-04-08 20:22:06,606 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed scratch disk check
2020-04-08 20:22:06,606 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed SE space check
2020-04-08 20:22:06,616 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed pilot activity check
2020-04-08 20:22:06,617 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed inclusion/exclusion/cloud
2020-04-08 20:22:06,853 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed hospital check
2020-04-08 20:22:07,071 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> 1 candidates passed overload check
2020-04-08 20:22:07,071 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702> getting the list of available files for user.cgottard:user.cgottard.HDBS3.data18_13TeV.periodF_EXT0.304432020
2020-04-08 20:22:07,410 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> totalInputSize=2 GB
2020-04-08 20:22:07,410 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702> final 1 candidates
2020-04-08 20:22:07,410 panda.log.AtlasAnalJobBroker: INFO     <jediTaskID=20990702>   use site=ANALY_DCSC with weight=0.0006257822277847309 nRunning=0 nDefined=967 nActivated=459 nStarting=159 nAssigned=12 nFailed=0 nClosed=0 nFinished=0 dataW=1 totalInGB=2 localInGB=2 nFiles=11 nLocalDisk=11 nLocalTape=0 nCache=0 nRemote=0 criteria=+use
2020-04-08 20:22:09,451 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702> sent
2020-04-08 20:22:09,451 panda.log.AtlasAnalJobBroker: DEBUG    <jediTaskID=20990702> done
```

This code change will view these kinds of sites as problematic sites and filter them out.

The to-running rate of sites are computed and printed in logs, but not used in algorithm yet. It can be used when adding more filters or adjusting weight in the future.

Still a draft request. Any comment is appreciated.
