### PR TITLE
Send task status messages to MQ

### DIFF
--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -27,7 +27,7 @@ from pandaserver.taskbuffer import JobUtils
 from pandaserver.taskbuffer import EventServiceUtils
 from .WorkQueueMapper import WorkQueueMapper
 
-from .JediTaskSpec import JediTaskSpec
+from .JediTaskSpec import JediTaskSpec, push_status_changes
 from .JediFileSpec import JediFileSpec
 from .JediDatasetSpec import JediDatasetSpec
 from .JediCacheSpec import JediCacheSpec
@@ -8387,9 +8387,9 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                 nRow += tmpRow
                 if tmpRow > 0 and not keepFlag:
                     self.record_task_status_change(jediTaskID)
-                    self.push_task_status_message(None, jediTaskID, varMap[':newStatus'], splitRule)
                 # update DEFT for timeout
                 if timeoutFlag:
+                    self.push_task_status_message(None, jediTaskID, varMap[':newStatus'], splitRule)
                     deftStatus = varMap[':newStatus']
                     self.setDeftStatus_JEDI(jediTaskID, deftStatus)
                     self.setSuperStatus_JEDI(jediTaskID,deftStatus)
@@ -13612,7 +13612,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
         if task_spec is not None:
             to_push = task_spec.push_status_changes()
         elif split_rule is not None:
-            to_push = JediTaskSpec.push_status_changes(split_rule)
+            to_push = push_status_changes(split_rule)
         # only run if to push status change
         if not to_push:
             return

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -37,7 +37,7 @@ from .MsgWrapper import MsgWrapper
 from . import ParseJobXML
 from . import JediCoreUtils
 
-from pandacommon.pandamsgbkr.msg_processor import MsgProcAgentBase
+from pandajedi.jediorder.JediMsgProcessor import MsgProcAgent
 
 # logger
 from pandacommon.pandalogger.PandaLogger import PandaLogger
@@ -72,7 +72,7 @@ for tmpHdr in tmpLoggerFiltered.handlers:
 def get_mb_proxy_dict():
     in_q_list = []
     out_q_list = ['jedi_taskstatus']
-    mq_agent = MsgProcAgentBase(config_file=jedi_config.mq.configFile)
+    mq_agent = MsgProcAgent(config_file=jedi_config.mq.configFile)
     mb_proxy_dict = mq_agent.start_passive_mode(prefetch_size=999)
     return mb_proxy_dict
 

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -8555,7 +8555,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                 nRow = self.cur.rowcount
                 if nRow > 0:
                     self.record_task_status_change(jediTaskID)
-                    self.push_task_status_message(None, jediTaskID, varMap[':newStatus'])
+                    # self.push_task_status_message(None, jediTaskID, varMap[':newStatus'])
                     tmpLog.debug('jediTaskID={0} reset to defined'.format(jediTaskID))
                     nTasks += 1
             # commit
@@ -9575,7 +9575,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                     self.cur.execute(sqlTT+comment,varMap)
                     # task status log
                     self.record_task_status_change(jediTaskID)
-                    self.push_task_status_message(None, jediTaskID, newTaskStatus)
+                    # self.push_task_status_message(None, jediTaskID, newTaskStatus)
                 else:
                     tmpLog.debug('back to taskStatus={0} for command={1}'.format(newTaskStatus,commStr))
                     varMap[':updateTime'] = datetime.datetime.utcnow()
@@ -10621,7 +10621,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                         tmpLog.info(errorDialog)
                         nTasks += 1
                         self.record_task_status_change(jediTaskID)
-                        self.push_task_status_message(None, jediTaskID, varMap[':newStatus'])
+                        # self.push_task_status_message(None, jediTaskID, varMap[':newStatus'])
                 except Exception:
                     tmpLog.debug('skip locked jediTaskID={0}'.format(jediTaskID))
                 # commit
@@ -10665,7 +10665,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
             tmpLog.debug('done with {0}'.format(nRow))
             if nRow > 0:
                 self.record_task_status_change(jediTaskID)
-                self.push_task_status_message(None, jediTaskID, varMap[':newStatus'])
+                # self.push_task_status_message(None, jediTaskID, varMap[':newStatus'])
             # commit
             if not self._commit():
                 raise RuntimeError('Commit error')
@@ -10736,7 +10736,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                 nRow += iRow
                 if iRow > 0:
                     self.record_task_status_change(jediTaskID)
-                    self.push_task_status_message(None, jediTaskID, None)
+                    # self.push_task_status_message(None, jediTaskID, None)
             # commit
             if not self._commit():
                 raise RuntimeError('Commit error')
@@ -10774,7 +10774,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
             tmpLog.debug('done with {0}'.format(nRow))
             if nRow > 0:
                 self.record_task_status_change(jediTaskID)
-                self.push_task_status_message(None, jediTaskID, None)
+                # self.push_task_status_message(None, jediTaskID, None)
             # commit
             if not self._commit():
                 raise RuntimeError('Commit error')
@@ -14204,7 +14204,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                 nRow = self.cur.rowcount
                 if nRow == 1:
                     self.record_task_status_change(jedi_taskid)
-                    self.push_task_status_message(None, jedi_taskid, varMap[':status'])
+                    # self.push_task_status_message(None, jedi_taskid, varMap[':status'])
                     n_updated += 1
                     tmpLog.debug('made pending jediTaskID={0}'.format(jedi_taskid))
                 elif nRow > 1:

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -13623,7 +13623,11 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
         tmpLog.debug('start')
         # send task status messages to mq
         try:
-            msg_dict = {'taskid': jedi_task_id, 'status': status}
+            msg_dict = {
+                    'msg_type': 'task_status',
+                    'taskid': jedi_task_id,
+                    'status': status,
+                }
             msg = json.dumps(msg_dict)
             if mb_proxy_dict is None:
                 mb_proxy_dict = get_mb_proxy_dict()

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -13618,6 +13618,9 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
         # only run if to push status change
         if not to_push:
             return
+        # skip statuses unnecessary to push
+        if status in ['pending']:
+            return
         comment = ' /* JediDBProxy.push_task_status_message */'
         methodName = self.getMethodName(comment)
         methodName += ' < jediTaskID={0} >'.format(jedi_task_id)
@@ -13626,7 +13629,7 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
         # send task status messages to mq
         try:
             now_time = datetime.datetime.utcnow()
-            now_ts = now_time.timestamp()
+            now_ts = int(now_time.timestamp())
             msg_dict = {
                     'msg_type': 'task_status',
                     'taskid': jedi_task_id,

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -68,7 +68,6 @@ for tmpHdr in tmpLoggerFiltered.handlers:
 
 
 # get mb proxies used in DBProxy methods
-mb_proxy_dict = None
 def get_mb_proxy_dict():
     if hasattr(jedi_config, 'mq') and hasattr(jedi_config.mq, 'configFile') and jedi_config.mq.configFile:
         # delay import to open logger file inside python daemon
@@ -95,6 +94,9 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
 
         # typical input cache
         self.typical_input_cache = {}
+
+        # mb proxy
+        self.mb_proxy_dict = None
 
 
     # connect to DB (just for INTR)
@@ -13629,11 +13631,11 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
                     'status': status,
                 }
             msg = json.dumps(msg_dict)
-            if mb_proxy_dict is None:
-                mb_proxy_dict = get_mb_proxy_dict()
-                if mb_proxy_dict is None:
+            if self.mb_proxy_dict is None:
+                self.mb_proxy_dict = get_mb_proxy_dict()
+                if self.mb_proxy_dict is None:
                     tmpLog.warning('Failed to get mb_proxy of internal MQs. Skipped ')
-            mb_proxy = mb_proxy_dict['out']['jedi_taskstatus']
+            mb_proxy = self.mb_proxy_dict['out']['jedi_taskstatus']
             if mb_proxy.got_disconnected:
                 mb_proxy.restart()
             mb_proxy.send(msg)

--- a/pandajedi/jedicore/JediDBProxy.py
+++ b/pandajedi/jedicore/JediDBProxy.py
@@ -13625,10 +13625,13 @@ class DBProxy(taskbuffer.OraDBProxy.DBProxy):
         tmpLog.debug('start')
         # send task status messages to mq
         try:
+            now_time = datetime.datetime.utcnow()
+            now_ts = now_time.timestamp()
             msg_dict = {
                     'msg_type': 'task_status',
                     'taskid': jedi_task_id,
                     'status': status,
+                    'timestamp': now_ts,
                 }
             msg = json.dumps(msg_dict)
             if self.mb_proxy_dict is None:

--- a/pandajedi/jedimsgprocessor/forwarding_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/forwarding_msg_processor.py
@@ -1,0 +1,30 @@
+from pandajedi.jedimsgprocessor.base_msg_processor import BaseMsgProcPlugin
+
+from pandacommon.pandalogger import logger_utils
+
+
+# logger
+base_logger = logger_utils.setup_logger(__name__.split('.')[-1])
+
+
+# forwarding message processing plugin
+class ForwardingMsgProcPlugin(BaseMsgProcPlugin):
+    """
+    Simply forward the message from one queue to another
+    """
+    def process(self, msg_obj):
+        # logger
+        tmp_log = logger_utils.make_logger(base_logger, method_name='process')
+        # start
+        # tmp_log.info('start')
+        # tmp_log.debug('sub_id={0} ; msg_id={1}'.format(msg_obj.sub_id, msg_obj.msg_id))
+        # run
+        try:
+            msg = msg_obj.data
+        except Exception as e:
+            err_str = 'failed to run, skipped. {0} : {1}'.format(e.__class__.__name__, e)
+            tmp_log.error(err_str)
+            raise
+        # done
+        # tmp_log.info('done')
+        return msg

--- a/pandajedi/jedimsgprocessor/forwarding_msg_processor.py
+++ b/pandajedi/jedimsgprocessor/forwarding_msg_processor.py
@@ -21,6 +21,7 @@ class ForwardingMsgProcPlugin(BaseMsgProcPlugin):
         # run
         try:
             msg = msg_obj.data
+            tmp_log.debug('forward message {0}'.format(msg))
         except Exception as e:
             err_str = 'failed to run, skipped. {0} : {1}'.format(e.__class__.__name__, e)
             tmp_log.error(err_str)

--- a/pandajedi/jediorder/JediKnight.py
+++ b/pandajedi/jediorder/JediKnight.py
@@ -8,11 +8,13 @@ from pandajedi.jedicore.ThreadUtils import ZombiCleaner
 
 class JediKnight(Interaction.CommandReceiveInterface):
     # constructor
-    def __init__(self, commuChannel, taskBufferIF, ddmIF, logger):
+    def __init__(self, commuChannel, taskBufferIF, ddmIF, logger, **kwargs):
         Interaction.CommandReceiveInterface.__init__(self, commuChannel)
         self.taskBufferIF = taskBufferIF
         self.ddmIF = ddmIF
         self.logger = logger
+        # intra-node message broker proxies
+        self.mb_proxy_dict = kwargs.get('mb_proxy_dict')
         # start zombie cleaner
         ZombiCleaner().start()
 

--- a/pandajedi/jediorder/JediMaster.py
+++ b/pandajedi/jediorder/JediMaster.py
@@ -14,7 +14,7 @@ from pandajedi.jedicore.JediTaskBufferInterface import JediTaskBufferInterface
 from pandajedi.jedicore.ThreadUtils import ZombiCleaner
 from pandajedi.jedicore.ProcessUtils import ProcessWrapper
 
-from pandacommon.pandamsgbkr.msg_processor import MsgProcAgentBase
+from pandajedi.jediorder.JediMsgProcessor import MsgProcAgent
 
 from pandajedi.jediconfig import jedi_config
 
@@ -67,7 +67,7 @@ class JediMaster:
         taskBufferIF = JediTaskBufferInterface()
         taskBufferIF.setupInterface()
         # setup intra-node message queue broker proxies
-        mq_agent = MsgProcAgentBase(config_file=jedi_config.mq.configFile)
+        mq_agent = MsgProcAgent(config_file=jedi_config.mq.configFile)
         mb_proxy_dict = mq_agent.start_passive_mode(prefetch_size=999)
         # the list of JEDI knights
         knightList = []

--- a/pandajedi/jediorder/JediMaster.py
+++ b/pandajedi/jediorder/JediMaster.py
@@ -65,9 +65,10 @@ class JediMaster:
         taskBufferIF = JediTaskBufferInterface()
         taskBufferIF.setupInterface()
         # setup intra-node message queue broker proxies
-        from pandajedi.jediorder.JediMsgProcessor import MsgProcAgent
-        mq_agent = MsgProcAgent(config_file=jedi_config.mq.configFile)
-        mb_proxy_dict = mq_agent.start_passive_mode(prefetch_size=999)
+        if hasattr(jedi_config, 'mq') and hasattr(jedi_config.mq, 'configFile') and jedi_config.mq.configFile:
+            from pandajedi.jediorder.JediMsgProcessor import MsgProcAgent
+            mq_agent = MsgProcAgent(config_file=jedi_config.mq.configFile)
+            mb_proxy_dict = mq_agent.start_passive_mode(prefetch_size=999)
         # the list of JEDI knights
         knightList = []
         # setup TaskRefiner

--- a/pandajedi/jediorder/JediMaster.py
+++ b/pandajedi/jediorder/JediMaster.py
@@ -14,6 +14,8 @@ from pandajedi.jedicore.JediTaskBufferInterface import JediTaskBufferInterface
 from pandajedi.jedicore.ThreadUtils import ZombiCleaner
 from pandajedi.jedicore.ProcessUtils import ProcessWrapper
 
+from pandacommon.pandamsgbkr.msg_processor import MsgProcAgentBase
+
 from pandajedi.jediconfig import jedi_config
 
 
@@ -64,6 +66,9 @@ class JediMaster:
         # setup TaskBuffer I/F
         taskBufferIF = JediTaskBufferInterface()
         taskBufferIF.setupInterface()
+        # setup intra-node message queue broker proxies
+        mq_agent = MsgProcAgentBase(config_file=jedi_config.mq.configFile)
+        mb_proxy_dict = mq_agent.start_passive_mode(prefetch_size=999)
         # the list of JEDI knights
         knightList = []
         # setup TaskRefiner

--- a/pandajedi/jediorder/JediMaster.py
+++ b/pandajedi/jediorder/JediMaster.py
@@ -14,8 +14,6 @@ from pandajedi.jedicore.JediTaskBufferInterface import JediTaskBufferInterface
 from pandajedi.jedicore.ThreadUtils import ZombiCleaner
 from pandajedi.jedicore.ProcessUtils import ProcessWrapper
 
-from pandajedi.jediorder.JediMsgProcessor import MsgProcAgent
-
 from pandajedi.jediconfig import jedi_config
 
 
@@ -67,6 +65,7 @@ class JediMaster:
         taskBufferIF = JediTaskBufferInterface()
         taskBufferIF.setupInterface()
         # setup intra-node message queue broker proxies
+        from pandajedi.jediorder.JediMsgProcessor import MsgProcAgent
         mq_agent = MsgProcAgent(config_file=jedi_config.mq.configFile)
         mb_proxy_dict = mq_agent.start_passive_mode(prefetch_size=999)
         # the list of JEDI knights

--- a/templates/panda_jedi.cfg.rpmnew.template
+++ b/templates/panda_jedi.cfg.rpmnew.template
@@ -328,4 +328,16 @@ modConfig = wlcg:any:pandajedi.jedisetup.GenTaskSetupper:GenTaskSetupper
 [msgprocessor]
 
 # json config file of message processors
-#configFile = /some/config.json
+#configFile = /etc/panda/jedi_msg_proc_config.json
+
+
+
+##########################
+#
+# Internal Message Queue parameters
+#
+
+[mq]
+
+# json config file of internal message queues
+#configFile = /etc/panda/jedi_mq_config.json


### PR DESCRIPTION
Introduction of current design:

- On JEDI node there runs a MQ service as the internal intra-node MQ
    - In panda_jedi.cfg one needs to configure in json in [mq] section about the internal MQ service and all the destination queues
    - One internal queue is "jedi_taskstatus" for task status change
    - As to the MQ software, will use RabbitMQ if no other concerns
- The mb_proxy instances of jedi_taskstatus queue is launched in JediDBProxy, letting record_task_status_change() send task status messages into jedi_taskstatus queue
    - The task status message is in the form of `{'taskid': jedi_task_id, 'status': status}`
    - Plan to add "status" argument in record_task_status_change() called in other methods, so that no need to query DB for the status again
    - Need to call jeditaskspec.push_status_changes() to decide whether to send message (TBD)
- Then, a message processor thread is running to forward messages from internal jedi_taskstatus queue to the external MQ (the message brokers for iDDS)
    - The message processor thread is configured in the json in [msgprocessor] section in panda_jedi.cfg
    - Message processor thread are guarded by the message processor agent which handles re-connection to external MQs
- BTW, mb_proxy instances of all internal queues are also launched in JediMaster, which can be passed to any JEDI agents for intra-node micro-service messaging in the future
- Requires new version of panda-common for msg_processor support

@tmaeno Any comments are welcome.
