### PR TITLE
misc

### DIFF
--- a/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
@@ -74,8 +74,8 @@ class AtlasAnalJobBroker(JobBrokerBase):
         siteAccessMap = {}
         for tmpSiteName,tmpAccess in siteAccessList:
             siteAccessMap[tmpSiteName] = tmpAccess
-        # disable VP for merging and forceStaged
-        if inputChunk.isMerging or taskSpec.avoid_vp():
+        # disable VP for merging, scouts, and forceStaged
+        if inputChunk.isMerging or taskSpec.avoid_vp() or taskSpec.useScout():
             useVP = False
         else:
             useVP = True

--- a/pandajedi/jedibrokerage/AtlasProdTaskBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdTaskBroker.py
@@ -705,10 +705,14 @@ class AtlasProdTaskBrokerThread (WorkerThread):
                             # with data
                             if availableData != {}:
                                 if availableData[tmpNucleus]['tot_size'] > 0:
-                                    weight *= float(availableData[tmpNucleus]['ava_size_any'])
-                                    weight /= float(availableData[tmpNucleus]['tot_size'])
-                                    wStr += '* ( available_input_size_DISKTAPE={0} )'.format(availableData[tmpNucleus]['ava_size_any'])
-                                    wStr += '/ ( total_input_size={0} )'.format(availableData[tmpNucleus]['tot_size'])
+                                    # use input size only when high IO intensity
+                                    if taskSpec.ioIntensity is None or taskSpec.ioIntensity > minIoIntensityWithLD:
+                                        weight *= float(availableData[tmpNucleus]['ava_size_any'])
+                                        weight /= float(availableData[tmpNucleus]['tot_size'])
+                                        wStr += '* ( available_input_size_DISKTAPE={0} )'.format(
+                                            availableData[tmpNucleus]['ava_size_any'])
+                                        wStr += '/ ( total_input_size={0} )'.format(
+                                            availableData[tmpNucleus]['tot_size'])
                                     # negative weight for tape
                                     if availableData[tmpNucleus]['ava_size_any'] > availableData[tmpNucleus]['ava_size_disk']:
                                         weight *= negWeightTape

--- a/pandajedi/jedibrokerage/AtlasProdTaskBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdTaskBroker.py
@@ -359,7 +359,7 @@ class AtlasProdTaskBrokerThread (WorkerThread):
                                                                                                                thrInputNum,
                                                                                                                thrInputSizeFrac,
                                                                                                                thrInputNumFrac))
-                    tmpLog.info('full-chain:{}'.format(taskSpec.get_full_chain()))
+                    tmpLog.info(f'full-chain:{taskSpec.get_full_chain()} ioIntensity={taskSpec.ioIntensity}')
                     # read task parameters
                     try:
                         taskParam = self.taskBufferIF.getTaskParamsWithID_JEDI(taskSpec.jediTaskID)


### PR DESCRIPTION
* exhausted -> running instead of scouting if already scouted
* to use input size in weights only for high IO intensity in AtlasProdTaskBroker
* to avoid VP for analysis scouts