### PR TITLE
Keep only rucio-clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ RUN mkdir /tmp/src
 WORKDIR /tmp/src
 COPY . .
 RUN /opt/panda/bin/pip install --no-cache-dir .[postgres]
-RUN /opt/panda/bin/pip install --no-cache-dir rucio
 RUN /opt/panda/bin/pip install --no-cache-dir rucio-clients
 
 RUN mkdir -p /etc/panda


### PR DESCRIPTION
According to Dimitrios the problem was fixed in 37.5.0, so pip3 install --upgrade rucio-clients==37.5.0 should fix the issue. 
