### PR TITLE
If pserverportcache is set to 443, use https

### DIFF
--- a/pandajedi/jedirefine/AtlasAnalTaskRefiner.py
+++ b/pandajedi/jedirefine/AtlasAnalTaskRefiner.py
@@ -34,7 +34,8 @@ class AtlasAnalTaskRefiner(TaskRefinerBase):
         if hasattr(panda_config, "wn_script_base_url"):
             base_url = panda_config.wn_script_base_url
         else:
-            base_url = f"http://{panda_config.pserveralias}:{panda_config.pserverportcache}"
+            protocol = "https" if panda_config.pserverportcache == 443 else "http"
+            base_url = f"{protocol}://{panda_config.pserveralias}:{panda_config.pserverportcache}"
         # set transPath
         if "transPath" not in taskParamMap:
             if "athena" in processingTypes:


### PR DESCRIPTION
If wn_script_base_url is not set and if pserverportcache is set to 443 (as it is for all k8s deployments), do not use http but https instead.